### PR TITLE
Converted test with unstable stimuli to run multiple times.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Modified
 
 - Fixed `isArbitrary` to handle `null` (threw error as `typeof null === "object"`)
+- Fixed partially failing test (#2)
 
 [0.0.2-diff]: https://github.com/rweda/configurable-arbitrary/compare/v0.0.1...v0.0.2
 


### PR DESCRIPTION
`uses reverse transformation to shrink` was occasionally given unshrinkable input, which would cause the test to fail (as shrinking unshrinkable input produces `null`).

Converted the test to generate input multiple times, and run the existing checks when the stimulus is valid.

Counts the number of unshrinkable input to make sure that both shrinkable and unshrinkable inputs are tested.

Closes #2.