### PR TITLE
Prevented '#arb' from swallowing errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/rweda/configurable-arbitrary/compare/v0.0.1...HEAD
 
+### Modified
+
+- Prevented `ConfigurableArbitrary#arb` from swallowing too many errors in `try`/`catch` block.
+
 ## [0.0.2] - 2017-07-14
 
 [Code][0.0.2] ([Diff][0.0.2-diff]) | [Changelog][0.0.2-log]

--- a/ConfigurableArbitrary.js
+++ b/ConfigurableArbitrary.js
@@ -57,12 +57,14 @@ class ConfigurableArbitrary {
    * @see https://github.com/jsverify/jsverify#types
   */
   static arb(opts) {
+    let jsverify;
     try {
-      return require("jsverify").record(this.collectSpecs(opts));
+      jsverify = require("jsverify");
     }
     catch (err) {
       throw new Error("'jsverify' is listed as an optionalDependency.  Make sure it's installed before calling 'arb'.");
     }
+    return jsverify.record(this.collectSpecs(opts));
   }
 
   /**

--- a/test/ConfigurableArbitrary/arb/doesnt-swallow-errors.js
+++ b/test/ConfigurableArbitrary/arb/doesnt-swallow-errors.js
@@ -1,0 +1,15 @@
+const test = require("ava");
+const sinon = require("sinon");
+const ConfigurableArbitrary = require("ConfigurableArbitrary");
+
+test.before("make 'collectSpecs' throw an error", () => {
+  sinon
+    .stub(ConfigurableArbitrary, "collectSpecs")
+    .throws(new TypeError("Don't swallow me!"));
+});
+
+test("doesn't swallow errors from '#collectSpecs()'", t => {
+  t.plan(2);
+  const err = t.throws(() => ConfigurableArbitrary.arb(), TypeError);
+  t.is(err.message, "Don't swallow me!");
+});


### PR DESCRIPTION
Closes #9.